### PR TITLE
return of hardware_usart.cpp it contains one function

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -20,6 +20,9 @@ ifeq ($(TARGET), native)
 	HEADERS += $(USART)/code/headers/test_usart.hpp
 	
 else
+    # source files in this library
+    SOURCES += $(USART)/code/src/hardware_usart.cpp
+
 	# header files in this library
 	HEADERS += $(USART)/code/headers/hardware_usart.hpp
 

--- a/code/headers/hardware_usart.hpp
+++ b/code/headers/hardware_usart.hpp
@@ -34,18 +34,7 @@ namespace r2d2::usart {
             {USART3, PIO_PD5B_RXD3, PIO_PD4B_TXD3, PIOD, peripheral::peripheral_b, ID_USART3}
     };
 
-    void set_peripheral(Pio *pio, uint32_t mask, peripheral p) {
-        uint32_t t = pio->PIO_ABSR;
-
-        if (p == peripheral::peripheral_a) {
-            pio->PIO_ABSR &= (~mask & t);
-        } else {
-            pio->PIO_ABSR = (mask | t);
-        }
-
-        // remove pin from pio controller
-        pio->PIO_PDR = mask;
-    };
+    void set_peripheral(Pio *pio, uint32_t mask, peripheral p);
 
     template <size_t BufferLength = 250>
     class hardware_usart_c : public usart_connection_c {
@@ -183,3 +172,4 @@ namespace r2d2::usart {
 
     };
 }; // namespace r2d2::usart
+

--- a/code/src/hardware_usart.cpp
+++ b/code/src/hardware_usart.cpp
@@ -1,0 +1,17 @@
+#include <hardware_usart.hpp>
+
+namespace r2d2::usart {
+
+    void set_peripheral(Pio *pio, uint32_t mask, peripheral p) {
+        uint32_t t = pio->PIO_ABSR;
+
+        if (p == peripheral::peripheral_a) {
+            pio->PIO_ABSR &= (~mask & t);
+        } else {
+            pio->PIO_ABSR = (mask | t);
+        }
+
+        // remove pin from pio controller
+        pio->PIO_PDR = mask;
+    };
+}


### PR DESCRIPTION
, namely set_peripheral because it causes linking errors somehow issue #25 is addressed in this 