### PR TITLE
Precise baud rate selection added 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,19 +10,6 @@ branches:
     - master
     - release
 
-addons:
-  apt_packages:
-    - lib32bz2-1.0
-    - lib32ncurses5
-    - lib32z1 
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-      - llvm-toolchain-precise 
-    packages:
-      - gcc-7
-      - g++-7
-
 cache:
   # cache the files for 3 hours
   timeout: 10800
@@ -31,30 +18,57 @@ cache:
     # cache the arm-none-eabi location
     - $HOME/arm-none-eabi
 
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+      - llvm-toolchain-precise 
+
 install:
   # clone git repo to the $HOME folder
-  - git clone --recursive -j8  https://github.com/R2D2-2019/R2D2-build.git $HOME/r2d2
-  
-  # make installer executable
-  - chmod +x $HOME/r2d2/programs/travis-ci/install_arm-eabi-gcc.sh
+  - git clone https://github.com/R2D2-2019/R2D2-build.git $HOME/r2d2 --depth=10
 
-  # run installer
-  - $HOME/r2d2/programs/travis-ci/install_arm-eabi-gcc.sh
-
-  # add arm-eabi-gcc to path
-  - export PATH=$PATH:$HOME/arm-none-eabi/bin/ 
-
-  # Change symlinks of gcc to gcc-7
-  - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-7 /usr/bin/gcc 
-  - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-7 /usr/bin/g++  
-
-  # link to /bin/ location
-  - sudo ln -s /usr/bin/gcc /bin/gcc
-  - sudo ln -s /usr/bin/g++ /bin/g++  
+  # update the submodules with a depth of 50 to limit the size a bit
+  - cd $HOME/r2d2
+  - git submodule update --init --depth=50
 
 jobs:
   include:
+    - stage: Tests
+      script:
+        # make installer executable
+        - chmod +x $HOME/r2d2/programs/travis-ci/install_arm-eabi-gcc.sh
+
+        # run installer
+        - $HOME/r2d2/programs/travis-ci/install_arm-eabi-gcc.sh
+
+        # add arm-eabi-gcc to path
+        - export PATH=$PATH:$HOME/arm-none-eabi/bin/ 
+        
+        # copy the currently building repo into a build_module
+        - cp -r $TRAVIS_BUILD_DIR $HOME/r2d2/modules/build_module
+
+        # go into the modules folder of the build system
+        - cd $HOME/r2d2/modules/build_module/code
+
+        # build the module
+        - make build
+        - make clean
+      name: "Arduino build"
+
     - script:
+      # install gcc/g++-7
+      - sudo apt-get -qq update
+      - sudo apt-get -qq install g++-7 -y
+
+      # Change symlinks of gcc to gcc-7
+      - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-7 /usr/bin/gcc 
+      - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-7 /usr/bin/g++  
+
+      # link to /bin/ location
+      - sudo ln -s /usr/bin/gcc /bin/gcc
+      - sudo ln -s /usr/bin/g++ /bin/g++  
+
       # copy the currently building repo into a build_module
       - cp -r $TRAVIS_BUILD_DIR $HOME/r2d2/modules/build_module
 
@@ -64,15 +78,5 @@ jobs:
       # build the module
       - make build 
       - make run
-      - make clean
-
-    - script:
-      # copy the currently building repo into a build_module
-      - cp -r $TRAVIS_BUILD_DIR $HOME/r2d2/modules/build_module
-
-      # go into the modules folder of the build system
-      - cd $HOME/r2d2/modules/build_module/code
-
-      # build the module
-      - make build
-      - make clean
+      - make clean        
+      name: "Native tests"

--- a/README.md
+++ b/README.md
@@ -34,50 +34,7 @@ auto usart = r2d2::usart::hardware_usart_c<r2d2::usart::usart0>(9600);
 ```
 The template parameter in the class is what usart port you want to use. **Warning** this is not the same port as the labels on the Arduino Due. The sam3x8e chip has 4 hardware usart ports, 3 of these ports have labels. The other port doesn't have a label. See the Doxygen or hardware_usart.hpp for the pin definitions.
 
-The first parameter is the baudrate, 9600 is used here as an example. Check which baudrate is applicable for you. With the higher baud rates (>= 115200 baud) there is a high chance of the usart not being withing the 3% error margin. Please use the calculation below to verify that the selected baud rate is within a 3% error margin. As the manufacturer does not recommend a higher error than 3%. 
-
-The current formula to calculate the register setting for the baud rate is:
-```
-register = (84'000'000 / 16) / baudrate;
-```
-
-To calculate the error use:
-```
-Error = 1 - (ExpectedBaudRate / ActualBaudRate)
-```
-
-This rounds some of the numbers down. If the error is higher than 3% use the following formula to get the baudrate within the 3% error margin. 
-
-If we calculate this number we can see that this will give us a float. We can use the data after the comma remove some of this error. As the usart will allow us to use fractions with 1/8 of a step.
-
-To use this we can call the other constructor. For example when we want to use the baudrate 230400 we have a error rate of 3.6% 
-```
-(84'000'000 / 16) / 230400 = 22.78 CD
-84'000'000 / (16 * 22) = 238'636 baud
-
-1 - (238'636 / 230'400) = 3.574%
-```
-
-To improve this we can use the data after the comma.
-```cpp
-0.78 ≈ 6/8
-
-84'000'000 / (16 * (22 + 6/8)) = 230'769 baud
-
-1 - (230'769 / 230'400) = 0.160%
-```
-As we can see the error went down from 3.6% to 0.2%.
-
-To use this other constructor we can simply call:
-```cpp
-#include <hardware_usart.hpp>
-
-auto usart = r2d2::usart::hardware_usart_c<r2d2::usart::usart0>({22, 6});
-```
-And this will set the correct settings in the register
-
-If there are multiple objects using the same usart the object that was constructed as last will set the baud rate, as this is set every time the constructor is called.
-
+The first parameter is the baudrate, 9600 is used here as an example. Check which baudrate is applicable for you. If there are multiple objects using the same usart the object that was constructed as last will set the baud rate, as this is set every time the constructor is called.
 
 ## Some examples
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,49 @@ auto usart = r2d2::usart::hardware_usart_c<r2d2::usart::usart0>(9600);
 ```
 The template parameter in the class is what usart port you want to use. **Warning** this is not the same port as the labels on the Arduino Due. The sam3x8e chip has 4 hardware usart ports, 3 of these ports have labels. The other port doesn't have a label. See the Doxygen or hardware_usart.hpp for the pin definitions.
 
-The first parameter is the baudrate, 9600 is used here as an example. Check which baudrate is applicable for you. If there are multiple objects using the same usart the object that was constructed as last will set the baud rate, as this is set every time the constructor is called.
+The first parameter is the baudrate, 9600 is used here as an example. Check which baudrate is applicable for you. With the higher baud rates (>= 115200 baud) there is a high chance of the usart not being withing the 3% error margin. Please use the calculation below to verify that the selected baud rate is within a 3% error margin. As the manufacturer does not recommend a higher error than 3%. 
+
+The current formula to calculate the register setting for the baud rate is:
+```
+register = (84'000'000 / 16) / baudrate;
+```
+
+To calculate the error use:
+```
+Error = 1 - (ExpectedBaudRate / ActualBaudRate)
+```
+
+This rounds some of the numbers down. If the error is higher than 3% use the following formula to get the baudrate within the 3% error margin. 
+
+If we calculate this number we can see that this will give us a float. We can use the data after the comma remove some of this error. As the usart will allow us to use fractions with 1/8 of a step.
+
+To use this we can call the other constructor. For example when we want to use the baudrate 230400 we have a error rate of 3.6% 
+```
+(84'000'000 / 16) / 230400 = 22.78 CD
+84'000'000 / (16 * 22) = 238'636 baud
+
+1 - (238'636 / 230'400) = 3.574%
+```
+
+To improve this we can use the data after the comma.
+```cpp
+0.78 ≈ 6/8
+
+84'000'000 / (16 * (22 + 6/8)) = 230'769 baud
+
+1 - (230'769 / 230'400) = 0.160%
+```
+As we can see the error went down from 3.6% to 0.2%.
+
+To use this other constructor we can simply call:
+```cpp
+#include <hardware_usart.hpp>
+
+auto usart = r2d2::usart::hardware_usart_c<r2d2::usart::usart0>({22, 6});
+```
+And this will set the correct settings in the register
+
+If there are multiple objects using the same usart the object that was constructed as last will set the baud rate, as this is set every time the constructor is called.
 
 
 ## Some examples

--- a/code/headers/hardware_usart.hpp
+++ b/code/headers/hardware_usart.hpp
@@ -259,7 +259,7 @@ namespace r2d2::usart {
 
             // write the baud rate in the BRGR register
             detail::usart::port<Bus>->US_BRGR =
-                (divider.divider | divider.fraction << 16);
+                (divider.divider | (divider.fraction & 0x7) << 16);
 
             // set the usart mode
             detail::usart::port<Bus>->US_MR =

--- a/code/headers/hardware_usart.hpp
+++ b/code/headers/hardware_usart.hpp
@@ -216,7 +216,7 @@ namespace r2d2::usart {
             __attribute__((error("Runtime usage of divider_calculator"))) {
 
             // calculate the base divider and fp
-            float divider = CHIP_FREQ_CPU_MAX / 16 * baudrate;
+            float divider = CHIP_FREQ_CPU_MAX / (16.f * baudrate);
 
             // calculate the cd
             uint16_t cd = static_cast<uint16_t>(divider);

--- a/code/headers/hardware_usart.hpp
+++ b/code/headers/hardware_usart.hpp
@@ -219,7 +219,7 @@ namespace r2d2::usart {
             float divider = CHIP_FREQ_CPU_MAX / 16 * baudrate;
 
             // calculate the cd
-            uint16_t cd = static_cast<uint16_t>(divider);       
+            uint16_t cd = static_cast<uint16_t>(divider);
 
             // get the data after the comma
             uint8_t fp = static_cast<uint8_t>(((divider - cd) + (1.f / 16.f)) * 8);
@@ -295,7 +295,9 @@ namespace r2d2::usart {
 
         /**
          * @brief Construct a hardware usart c object. Calculates a divider
-         * based on the the baud rate. Only sets the basic divider.
+         * based on the the baud rate. Calculates the divider on compile time.
+         * This will give an error when the calculate_divider is not optimized
+         * away. That means it wont compile with -O0
          *
          * @param baudrate
          */

--- a/code/main.cpp
+++ b/code/main.cpp
@@ -5,9 +5,9 @@ int main(void) {
     // kill the watchdog
     WDT->WDT_MR = WDT_MR_WDDIS;
     hwlib::wait_ms(1000);
-    hwlib::cout << "this works on arduino";
+    hwlib::cout << "this works on arduino\n";
 
-    auto usart = r2d2::usart::hardware_usart_c<r2d2::usart::usart0>(9600);
+    auto usart = r2d2::usart::hardware_usart_c<r2d2::usart::usart0>(r2d2::usart::usart_divider{45, 4});
 
     char t = 'a';
 

--- a/code/main.cpp
+++ b/code/main.cpp
@@ -7,7 +7,7 @@ int main() {
     hwlib::wait_ms(1000);
     hwlib::cout << "this works on arduino\n";
 
-    auto usart = r2d2::usart::hardware_usart_c<r2d2::usart::usart0>({45, 4});
+    auto usart = r2d2::usart::hardware_usart_c<r2d2::usart::usart0>(9600);
 
     char t = 'a';
 

--- a/code/main.cpp
+++ b/code/main.cpp
@@ -1,7 +1,7 @@
 #include <hwlib.hpp>
-
 #include <hardware_usart.hpp>
-int main(void) {
+
+int main() {
     // kill the watchdog
     WDT->WDT_MR = WDT_MR_WDDIS;
     hwlib::wait_ms(1000);

--- a/code/main.cpp
+++ b/code/main.cpp
@@ -7,7 +7,7 @@ int main(void) {
     hwlib::wait_ms(1000);
     hwlib::cout << "this works on arduino\n";
 
-    auto usart = r2d2::usart::hardware_usart_c<r2d2::usart::usart0>(r2d2::usart::usart_divider{45, 4});
+    auto usart = r2d2::usart::hardware_usart_c<r2d2::usart::usart0>({45, 4});
 
     char t = 'a';
 

--- a/code/main.cpp
+++ b/code/main.cpp
@@ -7,7 +7,7 @@ int main() {
     hwlib::wait_ms(1000);
     hwlib::cout << "this works on arduino\n";
 
-    auto usart = r2d2::usart::hardware_usart_c<r2d2::usart::usart0>(9600);
+    auto usart = r2d2::usart::hardware_usart_c<r2d2::usart::usart0>(115200);
 
     char t = 'a';
 


### PR DESCRIPTION
This adds the fraction support to the usart library. This makes the baud rate selection more precise. The conversion uses floats but this is optimized out as the function will give an error at compile time if it is not optimized away.